### PR TITLE
解决8.8.8..8递归查询大小写导致的记录请求日志失败

### DIFF
--- a/Dns/Core.go
+++ b/Dns/Core.go
@@ -4,12 +4,13 @@ import (
 	"DnsLog/Core"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/dns/dnsmessage"
 	"log"
 	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
 )
 
 var DnsData = make(map[string][]DnsInfo)
@@ -54,7 +55,7 @@ func serverDNS(addr *net.UDPAddr, conn *net.UDPConn, msg dnsmessage.Message) {
 	}
 	question := msg.Questions[0]
 	var (
-		queryNameStr = question.Name.String()
+		queryNameStr = strings.ToLower(question.Name.String())
 		queryType    = question.Type
 		queryName, _ = dnsmessage.NewName(queryNameStr)
 		resource     dnsmessage.Resource


### PR DESCRIPTION
#25 解决当dns设置为8.8.8.8没有记录dns请求的错误
测试发现8.8.8.8在递归请求时候域名大小写被该改变了，所以需要对8.8.8.8增加小写处理。
![image](https://github.com/user-attachments/assets/d085bf89-9dd6-4d71-a6ad-81e493467035)

![image](https://github.com/user-attachments/assets/354b46e3-afb2-48b3-b762-c0ce61ad07d2)
